### PR TITLE
fix pagination + remove batch, fixes #1

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,4 @@
 
-var Batch = require('batch');
 var Charges = require('./charges');
 var debug = require('debug')('stripe-cohort');
 var defaults = require('defaults');
@@ -26,7 +25,7 @@ function StripeCharges (key, options) {
   if (!(this instanceof StripeCharges)) return new StripeCharges(key, options);
   if (!key) throw new Error('Stripe cohort requires a Stripe key.');
   this.stripe = Stripe(key);
-  this.options = defaults(options, { count: 100, concurrency: 1 });
+  this.options = defaults(options, { count: 100 });
   var self = this;
   return function () { self.cohort.apply(self, arguments); };
 }
@@ -63,33 +62,21 @@ StripeCharges.prototype.charges = function (start, end, callback) {
   debug('loading charges with created [%s - %s] ..', start, end);
   var self = this;
   var charges = [];
-  var page = this.options.count;
-  // run the first query to get the total unpaginated count
-  this.query(start, end, 0, function (err, res) {
-    if (err) return callback(err);
-    var count = res.count;
-    charges.push.apply(charges, res.data);
-    var got = res.data.length;
-    var left = res.count - got;
-    // check if we grabbed everything in the first query
-    if (0 === left) return callback(null, charges);
-    // there's more, we have to paginate query
-    var pages = Math.ceil(left / page);
-    debug('loaded %d charges, %d left in %d pages of %d', got, left, pages, page);
-    var batch = new Batch();
-    batch.concurrency(self.options.concurrency);
-    range(0, pages).forEach(function (i) {
-      batch.push(function (done) { self.query(start, end, got + (i * page), done); });
-    });
-    batch.end(function (err, results) {
+  paginateQuery()
+
+  function paginateQuery (lastId) {
+    self.query(start, end, lastId, function (err, res) {
       if (err) return callback(err);
-      results.forEach(function (res) {
-        charges.push.apply(charges, res.data);
-      });
-      debug('finished loading all charges in cohort');
-      callback(null, charges);
-    });
-  });
+      charges.push.apply(charges, res.data);
+      // check if we grabbed everything in the first query
+      if (!res.has_more) return callback(null, charges);
+
+      // there's more, we have to paginate query
+      debug('loaded %d charges, has more to load', res.data.length);
+      var lastId = res.data[res.data.length - 1].id
+      paginateQuery(lastId)
+    })
+  }
 };
 
 /**
@@ -101,17 +88,17 @@ StripeCharges.prototype.charges = function (start, end, callback) {
  * @param {Function} callback
  */
 
-StripeCharges.prototype.query = function (start, end, offset, callback) {
-  debug('loading charges with created [%s - %s] with offset %d ..', start, end, offset);
+StripeCharges.prototype.query = function (start, end, startingAfter, callback) {
+  debug('loading charges with created [%s - %s] starting after %d ..', start, end, startingAfter);
   var options = {
     created: { gte: unixTime(start), lte: unixTime(end) },
-    count: this.options.count,
-    offset: offset
+    count: this.options.count
   };
+  if (startingAfter) options.starting_after = startingAfter
   this.stripe.charges.list(options, function (err, res) {
     if (err) return callback(err);
     var charges = res.data;
-    debug('loaded %d charges with offset %d', charges.length, offset);
+    debug('loaded %d charges starting after %d', charges.length, startingAfter);
     callback(null, res);
   });
 };

--- a/package.json
+++ b/package.json
@@ -13,12 +13,11 @@
   ],
   "dependencies": {
     "debug": "~0.7.4",
-    "unix-time": "~1.0.1",
-    "batch": "~0.5.0",
-    "range": "0.0.2",
     "defaults": "~1.0.0",
+    "range": "0.0.2",
+    "range-component": "~1.0.0",
     "stripe": "~2.4.2",
-    "range-component": "~1.0.0"
+    "unix-time": "~1.0.1"
   },
   "devDependencies": {
     "mocha": "~1.17.1"


### PR DESCRIPTION
This uses the new stripe pagination API. Unfortunately, they still [don't support auto pagination](https://github.com/stripe/stripe-node/issues/225) in the node API.

I had to remove batch because you can't use it with the new pagination mechanism.

Didn't know how to run the tests ¯\_(ツ)_/¯. But it seems to work =).